### PR TITLE
feat: allow overriding entrypoint by `--exec`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,6 +3,56 @@
 version = 4
 
 [[package]]
+name = "anstream"
+version = "0.6.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
+dependencies = [
+ "anstyle",
+ "anstyle-parse",
+ "anstyle-query",
+ "anstyle-wincon",
+ "colorchoice",
+ "is_terminal_polyfill",
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle"
+version = "1.0.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
+
+[[package]]
+name = "anstyle-parse"
+version = "0.2.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
+dependencies = [
+ "utf8parse",
+]
+
+[[package]]
+name = "anstyle-query"
+version = "1.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
+dependencies = [
+ "windows-sys",
+]
+
+[[package]]
+name = "anstyle-wincon"
+version = "3.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
+dependencies = [
+ "anstyle",
+ "once_cell",
+ "windows-sys",
+]
+
+[[package]]
 name = "bitflags"
 version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -28,6 +78,52 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "4.5.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3e77c3243bd94243c03672cb5154667347c457ca271254724f9f393aee1c05ff"
+dependencies = [
+ "clap_builder",
+ "clap_derive",
+]
+
+[[package]]
+name = "clap_builder"
+version = "4.5.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
+dependencies = [
+ "anstream",
+ "anstyle",
+ "clap_lex",
+ "strsim",
+]
+
+[[package]]
+name = "clap_derive"
+version = "4.5.28"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf4ced95c6f4a675af3da73304b9ac4ed991640c36374e4b46795c49e17cf1ed"
+dependencies = [
+ "heck",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
+
+[[package]]
+name = "colorchoice"
+version = "1.0.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "errno"
@@ -87,6 +183,18 @@ dependencies = [
  "wasi",
  "windows-targets",
 ]
+
+[[package]]
+name = "heck"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
+
+[[package]]
+name = "is_terminal_polyfill"
+version = "1.70.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "libc"
@@ -184,6 +292,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
 
 [[package]]
+name = "strsim"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7da8b5736845d9f2fcb837ea5d9e2628564b3b043a70948a3f0b778838c5fb4f"
+
+[[package]]
 name = "syn"
 version = "2.0.91"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -215,6 +329,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
+name = "utf8parse"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
+
+[[package]]
 name = "uuid"
 version = "1.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -228,6 +348,7 @@ dependencies = [
 name = "vscode-ipc-sock-hack"
 version = "1.0.0"
 dependencies = [
+ "clap",
  "exec",
  "tempfile",
  "uuid",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ edition = "2021"
 
 [dependencies]
 exec = "0.3.1"
+clap = { version = "4.4", features = ["derive"] }
 
 [dev-dependencies]
 tempfile = "3.16.0"

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -1,5 +1,5 @@
-use std::{fs, io, os::unix::net::UnixStream, path::Path};
 use clap::Parser;
+use std::{fs, io, os::unix::net::UnixStream, path::Path};
 
 #[derive(Parser, Debug, PartialEq)]
 #[command(author, version, about, long_about = None)]
@@ -202,7 +202,11 @@ mod tests {
         // 複数の引数があるケース
         let args = Args {
             exec: "cursor".to_string(),
-            args: vec!["-r".to_string(), "file1.txt".to_string(), "file2.txt".to_string()],
+            args: vec![
+                "-r".to_string(),
+                "file1.txt".to_string(),
+                "file2.txt".to_string(),
+            ],
         };
         let (exec, command_args) = build_command_args(args);
         assert_eq!(exec, "cursor", "exec command should be 'cursor'");
@@ -216,13 +220,23 @@ mod tests {
     #[test]
     fn test_args_parsing() {
         // オプションを含むケース
-        let args = Args::try_parse_from(["program", "--exec", "cursor", "-r", "--wait", "file.txt"]).unwrap();
+        let args =
+            Args::try_parse_from(["program", "--exec", "cursor", "-r", "--wait", "file.txt"])
+                .unwrap();
         assert_eq!(args.exec, "cursor", "exec should be set to 'cursor'");
-        assert_eq!(args.args, vec!["-r", "--wait", "file.txt"], "args should contain all options and the file path");
+        assert_eq!(
+            args.args,
+            vec!["-r", "--wait", "file.txt"],
+            "args should contain all options and the file path"
+        );
 
         // デフォルト値のテスト（オプション付き）
         let default_args = Args::try_parse_from(["program", "--wait", "file.txt"]).unwrap();
         assert_eq!(default_args.exec, "code", "exec should default to 'code'");
-        assert_eq!(default_args.args, vec!["--wait", "file.txt"], "args should contain the option and file path");
+        assert_eq!(
+            default_args.args,
+            vec!["--wait", "file.txt"],
+            "args should contain the option and file path"
+        );
     }
 }

--- a/bin/main.rs
+++ b/bin/main.rs
@@ -1,4 +1,23 @@
 use std::{fs, io, os::unix::net::UnixStream, path::Path};
+use clap::Parser;
+
+#[derive(Parser, Debug, PartialEq)]
+#[command(author, version, about, long_about = None)]
+struct Args {
+    /// Command to execute (default: code)
+    #[arg(long, default_value = "code")]
+    exec: String,
+
+    /// Arguments to pass to the command
+    #[arg(allow_hyphen_values = true, trailing_var_arg = true)]
+    args: Vec<String>,
+}
+
+fn build_command_args(args: Args) -> (String, Vec<String>) {
+    let mut command_args = vec![args.exec.clone()];
+    command_args.extend(args.args);
+    (args.exec, command_args)
+}
 
 fn is_like_vscode_ipc_socket(path: &Path) -> bool {
     if let Some(basename) = path.file_name() {
@@ -49,19 +68,15 @@ fn main() -> Result<(), exec::Error> {
         eprintln!("it seems you're not on remote.")
     }
 
-    let argv = vec![String::from("code")];
-    let argv = std::env::args().skip(1).fold(argv, |mut a, e| {
-        a.push(e);
-        a
-    });
-
-    Err(exec::execvp("code", argv))
+    let args = Args::parse();
+    let (exec, command_args) = build_command_args(args);
+    Err(exec::execvp(&exec, command_args))
 }
 
 #[cfg(test)]
 mod tests {
+    use super::*;
     use std::{os::unix::net::UnixListener, path::Path};
-
     use uuid::Uuid;
 
     use crate::{find_best_match_and_clean, is_like_vscode_ipc_socket};
@@ -154,5 +169,60 @@ mod tests {
         } else {
             panic!("expecting Ok(Some({:?})) but got {:?}", sock2, got)
         }
+    }
+
+    #[test]
+    fn test_build_command_args() {
+        // 通常のケース
+        let args = Args {
+            exec: "cursor".to_string(),
+            args: vec!["file.txt".to_string()],
+        };
+        let (exec, command_args) = build_command_args(args);
+        assert_eq!(exec, "cursor", "exec command should be 'cursor'");
+        assert_eq!(
+            command_args,
+            vec!["cursor", "file.txt"],
+            "command args should contain the command name and file path"
+        );
+
+        // 引数なしのケース
+        let args = Args {
+            exec: "code".to_string(),
+            args: vec![],
+        };
+        let (exec, command_args) = build_command_args(args);
+        assert_eq!(exec, "code", "exec command should be 'code'");
+        assert_eq!(
+            command_args,
+            vec!["code"],
+            "command args should contain only the command name"
+        );
+
+        // 複数の引数があるケース
+        let args = Args {
+            exec: "cursor".to_string(),
+            args: vec!["-r".to_string(), "file1.txt".to_string(), "file2.txt".to_string()],
+        };
+        let (exec, command_args) = build_command_args(args);
+        assert_eq!(exec, "cursor", "exec command should be 'cursor'");
+        assert_eq!(
+            command_args,
+            vec!["cursor", "-r", "file1.txt", "file2.txt"],
+            "command args should contain all arguments in order"
+        );
+    }
+
+    #[test]
+    fn test_args_parsing() {
+        // オプションを含むケース
+        let args = Args::try_parse_from(["program", "--exec", "cursor", "-r", "--wait", "file.txt"]).unwrap();
+        assert_eq!(args.exec, "cursor", "exec should be set to 'cursor'");
+        assert_eq!(args.args, vec!["-r", "--wait", "file.txt"], "args should contain all options and the file path");
+
+        // デフォルト値のテスト（オプション付き）
+        let default_args = Args::try_parse_from(["program", "--wait", "file.txt"]).unwrap();
+        assert_eq!(default_args.exec, "code", "exec should default to 'code'");
+        assert_eq!(default_args.args, vec!["--wait", "file.txt"], "args should contain the option and file path");
     }
 }


### PR DESCRIPTION
Allow passing a entrypoint other than `code`.